### PR TITLE
Use laravel prompts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,12 @@
         "allow-plugins": {
             "cweagans/composer-patches": true
         }
+    },
+    "extra": {
+        "patches": {
+            "laravel/prompts": {
+                "Add textarea, a multiline text input": "./patches/laravel-prompts/88.diff"
+            }
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require": {
         "symfony/console": "6.3.*",
         "symfony/yaml": "6.3.*",
-        "twig/twig": "3.8.*"
+        "twig/twig": "3.8.*",
+        "laravel/prompts": "0.1.*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,12 @@
         "symfony/console": "6.3.*",
         "symfony/yaml": "6.3.*",
         "twig/twig": "3.8.*",
-        "laravel/prompts": "0.1.*"
+        "laravel/prompts": "0.1.*",
+        "cweagans/composer-patches": "^1.7"
+    },
+    "config": {
+        "allow-plugins": {
+            "cweagans/composer-patches": true
+        }
     }
 }

--- a/patches/laravel-prompts/88.diff
+++ b/patches/laravel-prompts/88.diff
@@ -1,0 +1,626 @@
+diff --git a/playground/textarea.php b/playground/textarea.php
+new file mode 100644
+index 0000000..070305f
+--- /dev/null
++++ b/playground/textarea.php
+@@ -0,0 +1,14 @@
++<?php
++
++use function Laravel\Prompts\textarea;
++
++require __DIR__.'/../vendor/autoload.php';
++
++$email = textarea(
++    label: 'Tell me a story',
++    placeholder: 'Weave me a tale',
++);
++
++var_dump($email);
++
++echo str_repeat(PHP_EOL, 5);
+diff --git a/src/Concerns/Themes.php b/src/Concerns/Themes.php
+index 58de8c0..9a65d3d 100644
+--- a/src/Concerns/Themes.php
++++ b/src/Concerns/Themes.php
+@@ -14,6 +14,7 @@
+ use Laravel\Prompts\Spinner;
+ use Laravel\Prompts\SuggestPrompt;
+ use Laravel\Prompts\Table;
++use Laravel\Prompts\TextareaPrompt;
+ use Laravel\Prompts\TextPrompt;
+ use Laravel\Prompts\Themes\Default\ConfirmPromptRenderer;
+ use Laravel\Prompts\Themes\Default\MultiSearchPromptRenderer;
+@@ -26,6 +27,7 @@
+ use Laravel\Prompts\Themes\Default\SpinnerRenderer;
+ use Laravel\Prompts\Themes\Default\SuggestPromptRenderer;
+ use Laravel\Prompts\Themes\Default\TableRenderer;
++use Laravel\Prompts\Themes\Default\TextareaPromptRenderer;
+ use Laravel\Prompts\Themes\Default\TextPromptRenderer;
+ 
+ trait Themes
+@@ -43,6 +45,7 @@ trait Themes
+     protected static array $themes = [
+         'default' => [
+             TextPrompt::class => TextPromptRenderer::class,
++            TextareaPrompt::class => TextareaPromptRenderer::class,
+             PasswordPrompt::class => PasswordPromptRenderer::class,
+             SelectPrompt::class => SelectPromptRenderer::class,
+             MultiSelectPrompt::class => MultiSelectPromptRenderer::class,
+diff --git a/src/Concerns/TypedValue.php b/src/Concerns/TypedValue.php
+index afde293..33ff0c5 100644
+--- a/src/Concerns/TypedValue.php
++++ b/src/Concerns/TypedValue.php
+@@ -19,7 +19,7 @@ trait TypedValue
+     /**
+      * Track the value as the user types.
+      */
+-    protected function trackTypedValue(string $default = '', bool $submit = true, callable $ignore = null): void
++    protected function trackTypedValue(string $default = '', bool $submit = true, callable $ignore = null, bool $allowNewLine = false): void
+     {
+         $this->typedValue = $default;
+ 
+@@ -27,7 +27,7 @@ protected function trackTypedValue(string $default = '', bool $submit = true, ca
+             $this->cursorPosition = mb_strlen($this->typedValue);
+         }
+ 
+-        $this->on('key', function ($key) use ($submit, $ignore) {
++        $this->on('key', function ($key) use ($submit, $ignore, $allowNewLine) {
+             if ($key[0] === "\e" || in_array($key, [Key::CTRL_B, Key::CTRL_F, Key::CTRL_A, Key::CTRL_E])) {
+                 if ($ignore !== null && $ignore($key)) {
+                     return;
+@@ -51,10 +51,17 @@ protected function trackTypedValue(string $default = '', bool $submit = true, ca
+                     return;
+                 }
+ 
+-                if ($key === Key::ENTER && $submit) {
+-                    $this->submit();
++                if ($key === Key::ENTER) {
++                    if ($submit) {
++                        $this->submit();
+ 
+-                    return;
++                        return;
++                    }
++
++                    if ($allowNewLine) {
++                        $this->typedValue = mb_substr($this->typedValue, 0, $this->cursorPosition).PHP_EOL.mb_substr($this->typedValue, $this->cursorPosition);
++                        $this->cursorPosition++;
++                    }
+                 } elseif ($key === Key::BACKSPACE || $key === Key::CTRL_H) {
+                     if ($this->cursorPosition === 0) {
+                         return;
+@@ -87,14 +94,14 @@ protected function addCursor(string $value, int $cursorPosition, int $maxWidth):
+         $current = mb_substr($value, $cursorPosition, 1);
+         $after = mb_substr($value, $cursorPosition + 1);
+ 
+-        $cursor = mb_strlen($current) ? $current : ' ';
++        $cursor = mb_strlen($current) && $current !== PHP_EOL ? $current : ' ';
+ 
+-        $spaceBefore = $maxWidth - mb_strwidth($cursor) - (mb_strwidth($after) > 0 ? 1 : 0);
++        $spaceBefore = $maxWidth < 0 ? mb_strwidth($before) : $maxWidth - mb_strwidth($cursor) - (mb_strwidth($after) > 0 ? 1 : 0);
+         [$truncatedBefore, $wasTruncatedBefore] = mb_strwidth($before) > $spaceBefore
+             ? [$this->trimWidthBackwards($before, 0, $spaceBefore - 1), true]
+             : [$before, false];
+ 
+-        $spaceAfter = $maxWidth - ($wasTruncatedBefore ? 1 : 0) - mb_strwidth($truncatedBefore) - mb_strwidth($cursor);
++        $spaceAfter = $maxWidth < 0 ? mb_strwidth($after) : $maxWidth - ($wasTruncatedBefore ? 1 : 0) - mb_strwidth($truncatedBefore) - mb_strwidth($cursor);
+         [$truncatedAfter, $wasTruncatedAfter] = mb_strwidth($after) > $spaceAfter
+             ? [mb_strimwidth($after, 0, $spaceAfter - 1), true]
+             : [$after, false];
+@@ -102,6 +109,7 @@ protected function addCursor(string $value, int $cursorPosition, int $maxWidth):
+         return ($wasTruncatedBefore ? $this->dim('…') : '')
+             .$truncatedBefore
+             .$this->inverse($cursor)
++            .($current === PHP_EOL ? PHP_EOL : '')
+             .$truncatedAfter
+             .($wasTruncatedAfter ? $this->dim('…') : '');
+     }
+diff --git a/src/Key.php b/src/Key.php
+index bfbe2c9..48827d6 100644
+--- a/src/Key.php
++++ b/src/Key.php
+@@ -71,6 +71,11 @@ class Key
+      */
+     const CTRL_A = "\x01";
+ 
++    /**
++     * EOF
++     */
++    const CTRL_D = "\x04";
++
+     /**
+      * End
+      */
+diff --git a/src/TextareaPrompt.php b/src/TextareaPrompt.php
+new file mode 100644
+index 0000000..9225f89
+--- /dev/null
++++ b/src/TextareaPrompt.php
+@@ -0,0 +1,207 @@
++<?php
++
++namespace Laravel\Prompts;
++
++use Closure;
++
++class TextareaPrompt extends Prompt
++{
++    use Concerns\Scrolling;
++    use Concerns\TypedValue;
++
++    public int $width = 60;
++
++    /**
++     * Create a new TextareaPrompt instance.
++     */
++    public function __construct(
++        public string $label,
++        public int $rows = 5,
++        public string $placeholder = '',
++        public string $default = '',
++        public bool|string $required = false,
++        public ?Closure $validate = null,
++        public string $hint = ''
++    ) {
++        $this->trackTypedValue(
++            default: $default,
++            submit: false,
++            allowNewLine: true,
++        );
++
++        $this->scroll = $this->rows;
++
++        $this->initializeScrolling();
++
++        $this->on(
++            'key',
++            function ($key) {
++                if ($key[0] === "\e") {
++                    match ($key) {
++                        Key::UP, Key::UP_ARROW, Key::CTRL_P => $this->handleUpKey(),
++                        Key::DOWN, Key::DOWN_ARROW, Key::CTRL_N => $this->handleDownKey(),
++                        default => null,
++                    };
++
++                    return;
++                }
++
++                // Keys may be buffered.
++                foreach (mb_str_split($key) as $key) {
++                    if ($key === Key::CTRL_D) {
++                        $this->submit();
++
++                        return;
++                    }
++                }
++            }
++        );
++    }
++
++    /**
++     * Handle the up keypress.
++     */
++    protected function handleUpKey(): void
++    {
++        if ($this->cursorPosition === 0) {
++            return;
++        }
++
++        $lines = collect($this->lines());
++
++        // Line length + 1 for the newline character
++        $lineLengths = $lines->map(fn ($line, $index) => mb_strlen($line) + ($index === $lines->count() - 1 ? 0 : 1));
++
++        $currentLineIndex = $this->currentLineIndex();
++
++        if ($currentLineIndex === 0) {
++            // They're already at the first line, jump them to the first position
++            $this->cursorPosition = 0;
++
++            return;
++        }
++
++        $currentLines = $lineLengths->slice(0, $currentLineIndex + 1);
++
++        $currentColumn = $currentLines->last() - ($currentLines->sum() - $this->cursorPosition);
++
++        $destinationLineLength = $lineLengths->get($currentLineIndex - 1) ?? $currentLines->first();
++
++        $newColumn = min($destinationLineLength, $currentColumn);
++
++        if ($newColumn < $currentColumn) {
++            $newColumn--;
++        }
++
++        $fullLines = $currentLines->slice(0, -2);
++
++        $this->cursorPosition = $fullLines->sum() + $newColumn;
++    }
++
++    /**
++     * Handle the down keypress.
++     */
++    protected function handleDownKey(): void
++    {
++        $lines = collect($this->lines());
++
++        // Line length + 1 for the newline character
++        $lineLengths = $lines->map(fn ($line, $index) => mb_strlen($line) + ($index === $lines->count() - 1 ? 0 : 1));
++
++        $currentLineIndex = $this->currentLineIndex();
++
++        if ($currentLineIndex === $lines->count() - 1) {
++            // They're already at the last line, jump them to the last position
++            $this->cursorPosition = mb_strlen($lines->implode(PHP_EOL));
++
++            return;
++        }
++
++        // Lines up to and including the current line
++        $currentLines = $lineLengths->slice(0, $currentLineIndex + 1);
++
++        $currentColumn = $currentLines->last() - ($currentLines->sum() - $this->cursorPosition);
++
++        $destinationLineLength = ($lineLengths->get($currentLineIndex + 1) ?? $currentLines->last()) - 1;
++
++        $newColumn = min(max(0, $destinationLineLength), $currentColumn);
++
++        $this->cursorPosition = $currentLines->sum() + $newColumn;
++    }
++
++    /**
++     * The currently visible options.
++     *
++     * @return array<int, string>
++     */
++    public function visible(): array
++    {
++        $this->adjustVisibleWindow();
++
++        $withCursor = $this->valueWithCursor(10_000);
++
++        return array_slice(explode(PHP_EOL, $withCursor), $this->firstVisible, $this->scroll, preserve_keys: true);
++    }
++
++    protected function adjustVisibleWindow(): void
++    {
++        if (count($this->lines()) < $this->scroll) {
++            return;
++        }
++
++        $currentLineIndex = $this->currentLineIndex();
++
++        if ($this->firstVisible + $this->scroll <= $currentLineIndex) {
++            $this->firstVisible++;
++        }
++
++        if ($currentLineIndex === $this->firstVisible - 1) {
++            $this->firstVisible = max(0, $this->firstVisible - 1);
++        }
++
++        // Make sure there are always the scroll amount visible
++        if ($this->firstVisible + $this->scroll > count($this->lines())) {
++            $this->firstVisible = count($this->lines()) - $this->scroll;
++        }
++    }
++
++    /**
++     * Get the index of the current line that the cursor is on.
++     */
++    protected function currentLineIndex(): int
++    {
++        $totalLineLength = 0;
++
++        return (int) collect($this->lines())->search(function ($line) use (&$totalLineLength) {
++            $totalLineLength += mb_strlen($line) + 1;
++
++            return $totalLineLength > $this->cursorPosition;
++        }) ?: 0;
++    }
++
++    /**
++     * Get the formatted lines of the current value.
++     *
++     * @return array<int, string>
++     */
++    public function lines(): array
++    {
++        $value = wordwrap($this->value(), $this->width - 1, PHP_EOL, true);
++
++        return explode(PHP_EOL, $value);
++    }
++
++    /**
++     * Get the formatted value with a virtual cursor.
++     */
++    public function valueWithCursor(int $maxWidth): string
++    {
++        $value = implode(PHP_EOL, $this->lines());
++
++        if ($this->value() === '') {
++            return $this->dim($this->addCursor($this->placeholder, 0, 10_000));
++        }
++
++        return $this->addCursor($value, $this->cursorPosition, -1);
++    }
++}
+diff --git a/src/Themes/Default/TextareaPromptRenderer.php b/src/Themes/Default/TextareaPromptRenderer.php
+new file mode 100644
+index 0000000..4afb9f8
+--- /dev/null
++++ b/src/Themes/Default/TextareaPromptRenderer.php
+@@ -0,0 +1,85 @@
++<?php
++
++namespace Laravel\Prompts\Themes\Default;
++
++use Laravel\Prompts\TextareaPrompt;
++use Laravel\Prompts\Themes\Contracts\Scrolling;
++
++class TextareaPromptRenderer extends Renderer implements Scrolling
++{
++    use Concerns\DrawsBoxes;
++    use Concerns\DrawsScrollbars;
++
++    /**
++     * Render the textarea prompt.
++     */
++    public function __invoke(TextareaPrompt $prompt): string
++    {
++        $prompt->width = min($this->minWidth, $prompt->terminal()->cols() - 6);
++
++        return match ($prompt->state) {
++            'submit' => $this
++                ->box(
++                    $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
++                    collect($prompt->lines())->implode(PHP_EOL),
++                ),
++
++            'cancel' => $this
++                ->box(
++                    $this->truncate($prompt->label, $prompt->terminal()->cols() - 6),
++                    collect($prompt->lines())->map(fn ($line) => $this->strikethrough($this->dim($line)))->implode(PHP_EOL),
++                    color: 'red',
++                )
++                ->error('Cancelled.'),
++
++            'error' => $this
++                ->box(
++                    $this->truncate($prompt->label, $prompt->terminal()->cols() - 6),
++                    $this->renderText($prompt),
++                    color: 'yellow',
++                    info: 'Ctrl+D to submit'
++                )
++                ->warning($this->truncate($prompt->error, $prompt->terminal()->cols() - 5)),
++
++            default => $this
++                ->box(
++                    $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
++                    $this->renderText($prompt),
++                    info: 'Ctrl+D to submit'
++                )
++                ->when(
++                    $prompt->hint,
++                    fn () => $this->hint($prompt->hint),
++                    fn () => $this->newLine() // Space for errors
++                )
++        };
++    }
++
++    /**
++     * Render the text in the prompt.
++     */
++    protected function renderText(TextareaPrompt $prompt): string
++    {
++        $visible = collect($prompt->visible());
++
++        while ($visible->count() < $prompt->scroll) {
++            $visible->push('');
++        }
++
++        return $this->scrollbar(
++            $visible,
++            $prompt->firstVisible,
++            $prompt->scroll,
++            count($prompt->lines()),
++            $prompt->width,
++        )->implode(PHP_EOL);
++    }
++
++    /**
++     * The number of lines to reserve outside of the scrollable area.
++     */
++    public function reservedLines(): int
++    {
++        return 5;
++    }
++}
+diff --git a/src/helpers.php b/src/helpers.php
+index 178cb22..0219d60 100644
+--- a/src/helpers.php
++++ b/src/helpers.php
+@@ -13,6 +13,14 @@ function text(string $label, string $placeholder = '', string $default = '', boo
+     return (new TextPrompt($label, $placeholder, $default, $required, $validate, $hint))->prompt();
+ }
+ 
++/**
++ * Prompt the user for multiline text input.
++ */
++function textarea(string $label, int $rows = 5, string $placeholder = '', string $default = '', bool|string $required = false, Closure $validate = null, string $hint = ''): string
++{
++    return (new TextareaPrompt($label, $rows, $placeholder, $default, $required, $validate, $hint))->prompt();
++}
++
+ /**
+  * Prompt the user for input, hiding the value.
+  */
+diff --git a/tests/Feature/TextareaPromptTest.php b/tests/Feature/TextareaPromptTest.php
+new file mode 100644
+index 0000000..0b93b1a
+--- /dev/null
++++ b/tests/Feature/TextareaPromptTest.php
+@@ -0,0 +1,164 @@
++<?php
++
++use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
++use Laravel\Prompts\Key;
++use Laravel\Prompts\Prompt;
++use Laravel\Prompts\TextareaPrompt;
++
++use function Laravel\Prompts\textarea;
++
++it('returns the input', function () {
++    Prompt::fake(['J', 'e', 's', 's', Key::ENTER, 'J', 'o', 'e', Key::CTRL_D]);
++
++    $result = textarea(label: 'What is your name?');
++
++    expect($result)->toBe("Jess\nJoe");
++});
++
++it('accepts a default value', function () {
++    Prompt::fake([Key::CTRL_D]);
++
++    $result = textarea(
++        label: 'What is your name?',
++        default: "Jess\nJoe"
++    );
++
++    expect($result)->toBe("Jess\nJoe");
++});
++
++it('validates', function () {
++    Prompt::fake(['J', 'e', 's', Key::CTRL_D, 's', Key::CTRL_D]);
++
++    $result = textarea(
++        label: 'What is your name?',
++        validate: fn ($value) => $value !== 'Jess' ? 'Invalid name.' : '',
++    );
++
++    expect($result)->toBe('Jess');
++
++    Prompt::assertOutputContains('Invalid name.');
++});
++
++it('cancels', function () {
++    Prompt::fake([Key::CTRL_C]);
++
++    textarea(label: 'What is your name?');
++
++    Prompt::assertOutputContains('Cancelled.');
++});
++
++test('the backspace key removes a character', function () {
++    Prompt::fake(['J', 'e', 'z', Key::BACKSPACE, 's', 's', Key::CTRL_D]);
++
++    $result = textarea(label: 'What is your name?');
++
++    expect($result)->toBe('Jess');
++});
++
++test('the delete key removes a character', function () {
++    Prompt::fake(['J', 'e', 'z', Key::LEFT, Key::DELETE, 's', 's', Key::CTRL_D]);
++
++    $result = textarea(label: 'What is your name?');
++
++    expect($result)->toBe('Jess');
++});
++
++it('can fall back', function () {
++    Prompt::fallbackWhen(true);
++
++    TextareaPrompt::fallbackUsing(function (TextareaPrompt $prompt) {
++        expect($prompt->label)->toBe('What is your name?');
++
++        return 'result';
++    });
++
++    $result = textarea('What is your name?');
++
++    expect($result)->toBe('result');
++});
++
++it('supports emacs style key bindings', function () {
++    Prompt::fake(['J', 'z', 'e', Key::CTRL_B, Key::CTRL_H, key::CTRL_F, 's', 's', Key::CTRL_D]);
++
++    $result = textarea(label: 'What is your name?');
++
++    expect($result)->toBe('Jess');
++});
++
++it('moves to the beginning and end of line', function () {
++    Prompt::fake(['e', 's', Key::HOME[0], 'J', KEY::END[0], 's', Key::CTRL_D]);
++
++    $result = textarea(label: 'What is your name?');
++
++    expect($result)->toBe('Jess');
++});
++
++it('moves up and down lines', function () {
++    Prompt::fake([
++        'e', 's', 's', Key::ENTER, 'o', 'e',
++        KEY::UP_ARROW, KEY::LEFT_ARROW, Key::LEFT_ARROW,
++        'J', KEY::DOWN_ARROW, KEY::LEFT_ARROW, 'J', Key::CTRL_D,
++    ]);
++
++    $result = textarea(label: 'What is your name?');
++
++    expect($result)->toBe("Jess\nJoe");
++});
++
++it('moves to the start of the line if up is pressed twice on the first line', function () {
++    Prompt::fake([
++        'e', 's', 's', Key::ENTER, 'J', 'o', 'e',
++        KEY::UP_ARROW, KEY::UP_ARROW, 'J', Key::CTRL_D,
++    ]);
++
++    $result = textarea(label: 'What is your name?');
++
++    expect($result)->toBe("Jess\nJoe");
++});
++
++it('moves to the end of the line if down is pressed twice on the last line', function () {
++    Prompt::fake([
++        'J', 'e', 's', 's', Key::ENTER, 'J', 'o',
++        KEY::UP_ARROW, KEY::UP_ARROW, Key::DOWN_ARROW,
++        Key::DOWN_ARROW, 'e', Key::CTRL_D,
++    ]);
++
++    $result = textarea(label: 'What is your name?');
++
++    expect($result)->toBe("Jess\nJoe");
++});
++
++it('can move back to the last line when it is empty', function () {
++    Prompt::fake([
++        'J', 'e', 's', 's', Key::ENTER,
++        Key::UP, Key::DOWN,
++        'J', 'o', 'e',
++        Key::CTRL_D,
++    ]);
++
++    $result = textarea(label: 'What is your name?');
++
++    expect($result)->toBe("Jess\nJoe");
++});
++
++it('returns an empty string when non-interactive', function () {
++    Prompt::interactive(false);
++
++    $result = textarea('What is your name?');
++
++    expect($result)->toBe('');
++});
++
++it('returns the default value when non-interactive', function () {
++    Prompt::interactive(false);
++
++    $result = textarea('What is your name?', default: 'Taylor');
++
++    expect($result)->toBe('Taylor');
++});
++
++it('validates the default value when non-interactive', function () {
++    Prompt::interactive(false);
++
++    textarea('What is your name?', required: true);
++})->throws(NonInteractiveValidationException::class, 'Required.');

--- a/src/Console/Command/AddCommand.php
+++ b/src/Console/Command/AddCommand.php
@@ -88,10 +88,7 @@ class AddCommand extends Command {
      *   A map with two keys, name and url, for the organization.
      */
     protected function getOrganization() {
-        $not_empty = fn(string $value) => match (true) {
-            self::isNotEmpty($value) => 'Empty value',
-            default => null,
-        };
+        $not_empty = self::getNotEmptyClosure();
         $question = new TextPrompt('[1/2] What is the name of the organization?', 'Acme Inc', '', true, $not_empty);
         $name = $question->prompt();
         $question = new TextPrompt('[2/2] What is main URL for the organization?', 'https://example.org', '', true, $not_empty);
@@ -285,4 +282,13 @@ class AddCommand extends Command {
         ];
     }
 
+    /**
+     * Helper to get not empty validation closure.
+     */
+    private static function getNotEmptyClosure(): \Closure {
+        return fn(string $value) => match (true) {
+            self::isNotEmpty($value) => 'Empty value',
+            default => null,
+        };
+    }
 }

--- a/src/Console/Command/AddCommand.php
+++ b/src/Console/Command/AddCommand.php
@@ -3,6 +3,7 @@
 namespace ContribLog\Console\Command;
 
 use Laravel\Prompts\ConfirmPrompt;
+use Laravel\Prompts\TextPrompt;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -71,7 +72,7 @@ class AddCommand extends Command {
                 return Command::FAILURE;
             }
             $this->generateMinimalYaml();
-            $this->getOrganization($input, $output);
+            $this->getOrganization();
         }
         $project = $this->getProject($input, $output);
         $contribution = $this->getContribution($project, $input, $output);
@@ -83,22 +84,18 @@ class AddCommand extends Command {
     /**
      * Helper to get organization.
      *
-     * @param \Symfony\Component\Console\Input\InputInterface $input
-     *   Input object.
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
-     *   Output object.
-     *
      * @return array
      *   A map with two keys, name and url, for the organization.
      */
-    protected function getOrganization(InputInterface $input, OutputInterface $output) {
-        $helper = $this->getHelper('question');
-        $question = new Question('[1/2] What is the name of the organization? ');
-        $question->setValidator([self::class, 'isNotEmpty']);
-        $name = $helper->ask($input, $output, $question);
-        $question = new Question('What is main URL for the organization? ');
-        $question->setValidator([self::class, 'isNotEmpty']);
-        $url = $helper->ask($input, $output, $question);
+    protected function getOrganization() {
+        $not_empty = fn(string $value) => match (true) {
+            self::isNotEmpty($value) => 'Empty value',
+            default => null,
+        };
+        $question = new TextPrompt('[1/2] What is the name of the organization?', 'Acme Inc', '', true, $not_empty);
+        $name = $question->prompt();
+        $question = new TextPrompt('[2/2] What is main URL for the organization?', 'https://example.org', '', true, $not_empty);
+        $url = $question->prompt();
         $this->contributions['organization'] = [
             'name' => $name,
             'url' => $url,

--- a/src/Console/Command/AddCommand.php
+++ b/src/Console/Command/AddCommand.php
@@ -2,8 +2,6 @@
 
 namespace ContribLog\Console\Command;
 
-use Laravel\Prompts\ConfirmPrompt;
-use Laravel\Prompts\TextPrompt;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -11,6 +9,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\text;
 
 /**
  * Add command.
@@ -64,11 +64,15 @@ class AddCommand extends Command {
         }
         catch (\InvalidArgumentException $exception) {
             // File does not exist yet.
-            $question = new ConfirmPrompt(sprintf('The "%s" file does not exist yet. Do you want to generate it? (y/n) ', $yml_file), false);
-            $create_file = $question->prompt();
+            $create_file = confirm(
+                label: sprintf('The "%s" file does not exist yet. Do you want to generate it? (y/n) ', $yml_file),
+                default: false,
+                hint: 'A contributions file is needed to continue.'
+            );
             if (!$create_file) {
                 // Nothing else to do, cannot continue, hence fail.
-                $output->writeln('<error>A contributions YAML file is needed to continue. See an examples directory or accept to generate it while runnind add command.</error>');
+                $output->writeln('<error>A contributions YAML file is needed to continue.</error>');
+                $output->writeln('<error>See an examples directory or accept to generate it while running the add command.</error>');
                 return Command::FAILURE;
             }
             $this->generateMinimalYaml();
@@ -89,10 +93,18 @@ class AddCommand extends Command {
      */
     protected function getOrganization() {
         $not_empty = self::getNotEmptyClosure();
-        $question = new TextPrompt('[1/2] What is the name of the organization?', 'Acme Inc', '', true, $not_empty);
-        $name = $question->prompt();
-        $question = new TextPrompt('[2/2] What is main URL for the organization?', 'https://example.org', '', true, $not_empty);
-        $url = $question->prompt();
+        $name = text(
+            label: '[1/2] What is the name of the organization?',
+            placeholder: 'Acme Inc',
+            required: true,
+            validate: $not_empty
+        );
+        $url = text(
+            label: '[2/2] What is main URL for the organization?',
+            placeholder: 'https://example.org',
+            required: true,
+            validate: $not_empty
+        );
         $this->contributions['organization'] = [
             'name' => $name,
             'url' => $url,

--- a/src/Console/Command/AddCommand.php
+++ b/src/Console/Command/AddCommand.php
@@ -2,13 +2,13 @@
 
 namespace ContribLog\Console\Command;
 
+use Laravel\Prompts\ConfirmPrompt;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 
 /**
@@ -63,9 +63,9 @@ class AddCommand extends Command {
         }
         catch (\InvalidArgumentException $exception) {
             // File does not exist yet.
-            $helper = $this->getHelper('question');
-            $question = new ConfirmationQuestion(sprintf('The "%s" file does not exist yet. Do you want to generate initialize it? (y/n) ', $yml_file), false);
-            if (!$helper->ask($input, $output, $question)) {
+            $question = new ConfirmPrompt(sprintf('The "%s" file does not exist yet. Do you want to generate it? (y/n) ', $yml_file), false);
+            $create_file = $question->prompt();
+            if (!$create_file) {
                 // Nothing else to do, cannot continue, hence fail.
                 $output->writeln('<error>A contributions YAML file is needed to continue. See an examples directory or accept to generate it while runnind add command.</error>');
                 return Command::FAILURE;


### PR DESCRIPTION
[laravel/prompts](https://laravel.com/docs/10.x/prompts) seems to improve a lot the user experience compared with raw symfony console.
It is actually built on top of symfony console.

One of the things it lacks is a widget for multi-line input, but there is an open PR at https://github.com/laravel/prompts/pull/88 that provides that.

So, to be able to use that, I also needed to add [cweagans/composer-patches](https://www.cweagans.net/project/composer-patches/).
I added a local diff instead of downloading it dynamically, currently tested with laravel prompts at `v0.1.13`.

Overall, this adds many dependencies, but the boost in UX is quite nice, so I will take that for now.
If this proves to be hard to maintain, raw symfony console approach will be there.

cc @diegoe